### PR TITLE
Modify mem stats to report MMapped memory only

### DIFF
--- a/object_store_test.go
+++ b/object_store_test.go
@@ -123,6 +123,46 @@ func TestAddingAndDeletingLargeNumberOfObjects(t *testing.T) {
 	})
 }
 
+func TestMemStats63Objects(t *testing.T) {
+	objectsPerSlab := uint(63)
+	objectSize := uint8(10)
+
+	objects := [][]byte{
+		[]byte("1234567890"),
+	}
+
+	os := NewObjectStore(objectsPerSlab)
+	for _, o := range objects {
+		os.Add(o)
+	}
+
+	Convey("When using less than 64 objects per slab", t, func() {
+		memSize, err := os.MemStatsByObjSize(objectSize)
+		So(err, ShouldBeNil)
+		So(memSize, ShouldEqual, (1 + 32 + 8 + (10 * 63)))
+	})
+}
+
+func TestMemStats65Objects(t *testing.T) {
+	objectsPerSlab := uint(65)
+	objectSize := uint8(10)
+
+	objects := [][]byte{
+		[]byte("1234567890"),
+	}
+
+	os := NewObjectStore(objectsPerSlab)
+	for _, o := range objects {
+		os.Add(o)
+	}
+
+	Convey("When using less than 64 objects per slab", t, func() {
+		memSize, err := os.MemStatsByObjSize(objectSize)
+		So(err, ShouldBeNil)
+		So(memSize, ShouldEqual, (1 + 32 + 16 + (10 * 65)))
+	})
+}
+
 func BenchmarkAddingDeleting(b *testing.B) {
 	os := NewObjectStore(100)
 

--- a/slab_pool.go
+++ b/slab_pool.go
@@ -33,7 +33,25 @@ func NewSlabPool(objSize uint8, objsPerSlab uint) *slabPool {
 	}
 }
 
-func (s *slabPool) getMemStats() uint64 {
+func (s *slabPool) fragStats() float32 {
+	length := float32(len(s.slabs))
+
+	if length < 1 {
+		return 0.0
+	}
+
+	var total float32
+
+	// iterate over all slabs in the pool
+	// get fragmentation percent
+	for _, sl := range s.slabs {
+		total += float32(sl.bitSet().Count()) / float32(sl.objsPerSlab())
+	}
+
+	return total / length
+}
+
+func (s *slabPool) memStats() uint64 {
 	length := uint64(len(s.slabs))
 
 	if length < 1 {

--- a/slab_pool.go
+++ b/slab_pool.go
@@ -33,6 +33,18 @@ func NewSlabPool(objSize uint8, objsPerSlab uint) *slabPool {
 	}
 }
 
+func (s *slabPool) getMemStats() uint64 {
+	length := uint64(len(s.slabs))
+
+	if length < 1 {
+		return 0
+	}
+
+	// add MMapped slab usage for the pool
+	slabLength := uint64(s.slabs[0].getTotalLength())
+	return length * slabLength
+}
+
 func (s *slabPool) getNextSlabID(current, objHash uint) uint {
 	slabCount := uint(len(s.slabs))
 	if objHash >= slabCount {


### PR DESCRIPTION
This modifies mem stats methods in the object store to only report on MMapped memory. The go heap profiler will report on any overhead from the maps, slices, and structs being used in the store. The gap exists to get an accurate measurement of MMapped memory.