### PR TITLE
Add configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,27 @@
+package gos
+
+// Config provides an ObjectStoreConfig with default settings.
+var Config = NewConfig()
+
+// ObjectStoreConfig is used by the object store when creating a new instance.
+// Please see the documentation at https://github.com/replay/go-generic-object-store
+// for more information
+type ObjectStoreConfig struct {
+	GrowSlabs          bool
+	BaseObjectsPerSlab uint
+	GrowthExponent     float64 // for use with math.Pow this is easier
+	GrowthFactor       float64 // ^^
+}
+
+// NewConfig returns a new object store configuration with
+// default settings. Please see the documentation at
+// https://github.com/replay/go-generic-object-store for
+// more information.
+func NewConfig() ObjectStoreConfig {
+	return ObjectStoreConfig{
+		GrowSlabs:          true,
+		BaseObjectsPerSlab: 25,
+		GrowthExponent:     5,
+		GrowthFactor:       1.3,
+	}
+}

--- a/config.go
+++ b/config.go
@@ -7,7 +7,6 @@ var Config = NewConfig()
 // Please see the documentation at https://github.com/replay/go-generic-object-store
 // for more information
 type ObjectStoreConfig struct {
-	GrowSlabs          bool
 	BaseObjectsPerSlab uint
 	GrowthExponent     float64 // for use with math.Pow this is easier
 	GrowthFactor       float64 // ^^
@@ -19,7 +18,6 @@ type ObjectStoreConfig struct {
 // more information.
 func NewConfig() ObjectStoreConfig {
 	return ObjectStoreConfig{
-		GrowSlabs:          true,
 		BaseObjectsPerSlab: 25,
 		GrowthExponent:     5,
 		GrowthFactor:       1.3,

--- a/object_store.go
+++ b/object_store.go
@@ -105,7 +105,6 @@ func (o *ObjectStore) MemStatsTotal() (uint64, error) {
 type ObjectStore struct {
 	slabPools   map[uint8]*slabPool
 	lookupTable []SlabAddr
-	objsPerSlab uint
 	config      ObjectStoreConfig
 }
 
@@ -113,9 +112,8 @@ type ObjectStore struct {
 // Once an object store has been initialized its configuration cannot be changed
 func NewObjectStore(c ObjectStoreConfig) ObjectStore {
 	return ObjectStore{
-		config:      c,
-		objsPerSlab: c.BaseObjectsPerSlab,
-		slabPools:   make(map[uint8]*slabPool),
+		config:    c,
+		slabPools: make(map[uint8]*slabPool),
 	}
 }
 
@@ -197,7 +195,7 @@ func (o *ObjectStore) Add(obj []byte) (ObjAddr, error) {
 
 // addSlabPool adds a slab pool of the specified size to this object store
 func (o *ObjectStore) addSlabPool(size uint8) {
-	o.slabPools[size] = NewSlabPool(size, o.objsPerSlab)
+	o.slabPools[size] = NewSlabPool(size, o.config.BaseObjectsPerSlab)
 }
 
 // Search searches for the given value in the accordingly sized slab pool

--- a/object_store.go
+++ b/object_store.go
@@ -106,13 +106,15 @@ type ObjectStore struct {
 	slabPools   map[uint8]*slabPool
 	lookupTable []SlabAddr
 	objsPerSlab uint
+	config      ObjectStoreConfig
 }
 
-// NewObjectStore initializes a new object store with the given number of objects per slab,
-// it returns the object store as a value
-func NewObjectStore(objsPerSlab uint) ObjectStore {
+// NewObjectStore initializes a new object store with the given configuration
+// Once an object store has been initialized its configuration cannot be changed
+func NewObjectStore(c ObjectStoreConfig) ObjectStore {
 	return ObjectStore{
-		objsPerSlab: objsPerSlab,
+		config:      c,
+		objsPerSlab: c.BaseObjectsPerSlab,
 		slabPools:   make(map[uint8]*slabPool),
 	}
 }

--- a/object_store_test.go
+++ b/object_store_test.go
@@ -48,7 +48,7 @@ func TestAddingAndDeletingObjects(t *testing.T) {
 	expectedSlabs := uint(3)
 	c := NewConfig()
 	c.BaseObjectsPerSlab = objectsPerSlab
-	c.GrowSlabs = false
+	c.GrowthExponent = 1
 	os := NewObjectStore(c)
 
 	testData := make(map[string]ObjAddr)
@@ -95,7 +95,7 @@ func TestAddingAndDeletingLargeNumberOfObjects(t *testing.T) {
 
 	c := NewConfig()
 	c.BaseObjectsPerSlab = objectsPerSlab
-	c.GrowSlabs = false
+	c.GrowthExponent = 1
 	os := NewObjectStore(c)
 
 	Convey("When adding lots of test data to object store", t, func() {
@@ -139,7 +139,7 @@ func TestMemStats63Objects(t *testing.T) {
 
 	c := NewConfig()
 	c.BaseObjectsPerSlab = objectsPerSlab
-	c.GrowSlabs = false
+	c.GrowthExponent = 1
 	os := NewObjectStore(c)
 	for _, o := range objects {
 		os.Add(o)
@@ -162,7 +162,7 @@ func TestMemStats65Objects(t *testing.T) {
 
 	c := NewConfig()
 	c.BaseObjectsPerSlab = objectsPerSlab
-	c.GrowSlabs = false
+	c.GrowthExponent = 1
 	os := NewObjectStore(c)
 	for _, o := range objects {
 		os.Add(o)
@@ -178,7 +178,7 @@ func TestMemStats65Objects(t *testing.T) {
 func BenchmarkAddingDeleting(b *testing.B) {
 	c := NewConfig()
 	c.BaseObjectsPerSlab = 100
-	c.GrowSlabs = false
+	c.GrowthExponent = 1
 	os := NewObjectStore(c)
 
 	testData := make(map[string]ObjAddr)
@@ -205,7 +205,7 @@ func BenchmarkSearchingForValue(b *testing.B) {
 
 	c := NewConfig()
 	c.BaseObjectsPerSlab = 100
-	c.GrowSlabs = false
+	c.GrowthExponent = 1
 	os := NewObjectStore(c)
 
 	for i := 0; i < testValueCount; i++ {

--- a/object_store_test.go
+++ b/object_store_test.go
@@ -18,7 +18,7 @@ func TestAddingGettingObjects13(t *testing.T) {
 }
 
 func testAddingGettingObjects(t *testing.T, objPerSlab, start, stop uint64) {
-	os := NewObjectStore(uint(objPerSlab))
+	os := NewObjectStore(NewConfig())
 
 	testData := make(map[string]ObjAddr)
 	for i := start; i < stop; i++ {
@@ -46,7 +46,10 @@ func testAddingGettingObjects(t *testing.T, objPerSlab, start, stop uint64) {
 func TestAddingAndDeletingObjects(t *testing.T) {
 	objectsPerSlab := uint(3)
 	expectedSlabs := uint(3)
-	os := NewObjectStore(objectsPerSlab)
+	c := NewConfig()
+	c.BaseObjectsPerSlab = objectsPerSlab
+	c.GrowSlabs = false
+	os := NewObjectStore(c)
 
 	testData := make(map[string]ObjAddr)
 	for i := uint(0); i < objectsPerSlab*expectedSlabs; i++ {
@@ -90,7 +93,10 @@ func TestAddingAndDeletingLargeNumberOfObjects(t *testing.T) {
 		testData[fmt.Sprintf("%0"+strconv.Itoa(objectSizes[i%uint(len(objectSizes))])+"d", i)] = 0
 	}
 
-	os := NewObjectStore(objectsPerSlab)
+	c := NewConfig()
+	c.BaseObjectsPerSlab = objectsPerSlab
+	c.GrowSlabs = false
+	os := NewObjectStore(c)
 
 	Convey("When adding lots of test data to object store", t, func() {
 		for k := range testData {
@@ -131,7 +137,10 @@ func TestMemStats63Objects(t *testing.T) {
 		[]byte("1234567890"),
 	}
 
-	os := NewObjectStore(objectsPerSlab)
+	c := NewConfig()
+	c.BaseObjectsPerSlab = objectsPerSlab
+	c.GrowSlabs = false
+	os := NewObjectStore(c)
 	for _, o := range objects {
 		os.Add(o)
 	}
@@ -151,7 +160,10 @@ func TestMemStats65Objects(t *testing.T) {
 		[]byte("1234567890"),
 	}
 
-	os := NewObjectStore(objectsPerSlab)
+	c := NewConfig()
+	c.BaseObjectsPerSlab = objectsPerSlab
+	c.GrowSlabs = false
+	os := NewObjectStore(c)
 	for _, o := range objects {
 		os.Add(o)
 	}
@@ -164,7 +176,10 @@ func TestMemStats65Objects(t *testing.T) {
 }
 
 func BenchmarkAddingDeleting(b *testing.B) {
-	os := NewObjectStore(100)
+	c := NewConfig()
+	c.BaseObjectsPerSlab = 100
+	c.GrowSlabs = false
+	os := NewObjectStore(c)
 
 	testData := make(map[string]ObjAddr)
 	for i := 0; i < 99999; i++ {
@@ -187,7 +202,11 @@ func BenchmarkAddingDeleting(b *testing.B) {
 func BenchmarkSearchingForValue(b *testing.B) {
 	testValueCount := 1000000
 	testValues := make([][]byte, testValueCount)
-	os := NewObjectStore(100)
+
+	c := NewConfig()
+	c.BaseObjectsPerSlab = 100
+	c.GrowSlabs = false
+	os := NewObjectStore(c)
 
 	for i := 0; i < testValueCount; i++ {
 		testValues[i] = []byte(fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%d", i)))))


### PR DESCRIPTION
Part of implementing variable sized slabs in pools. I left `objsPerSlab` in `ObjectStore` to avoid making a lot of code changes. Feel free to remove it in your next PR that implements the rest of the new logic.

See also: #18 